### PR TITLE
Outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pre--commit-green.svg)](https://anaconda.org/conda-forge/pre-commit) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pre-commit.svg)](https://anaconda.org/conda-forge/pre-commit) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pre-commit.svg)](https://anaconda.org/conda-forge/pre-commit) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pre-commit.svg)](https://anaconda.org/conda-forge/pre-commit) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pre_commit-green.svg)](https://anaconda.org/conda-forge/pre_commit) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pre_commit.svg)](https://anaconda.org/conda-forge/pre_commit) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pre_commit.svg)](https://anaconda.org/conda-forge/pre_commit) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pre_commit.svg)](https://anaconda.org/conda-forge/pre_commit) |
 
 Installing pre-commit
 =====================
@@ -121,10 +122,10 @@ Installing `pre-commit` from the `conda-forge` channel can be achieved by adding
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `pre-commit` can be installed with:
+Once the `conda-forge` channel has been enabled, `pre-commit, pre_commit` can be installed with:
 
 ```
-conda install pre-commit
+conda install pre-commit pre_commit
 ```
 
 It is possible to list all of the versions of `pre-commit` available on your platform with:

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,1 @@
+%PYTHON% -m pip install . --no-deps -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,1 @@
+${PYTHON} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: pre-commit
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
-  sha256: 62c09f83cbac0904c9aff0a6412f5db2d10e1756fa6c1fc05eeefa15b677fb80
+  sha256: 0b80e45b4e001f45bade0f1cc2d891eb810de154f1eb703a1f77ac060a9a07ae
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,11 +35,14 @@ outputs:
         - toml
         - virtualenv >=15.2
     test:
+      requires:
+        - pip
       imports:
         - pre_commit
         - pre_commit.commands
         - pre_commit.languages
       commands:
+        - pip check
         - pre-commit --help
         - pre-commit-validate-config --help
         - pre-commit-validate-manifest --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,51 +1,58 @@
-{% set name = "pre-commit" %}
 {% set version = "2.1.0" %}
-{% set hash_type = "sha256" %}
-{% set hash = "62c09f83cbac0904c9aff0a6412f5db2d10e1756fa6c1fc05eeefa15b677fb80" %}
 
 package:
-  name: {{ name }}
+  name: pre-commit
   version: {{ version }}
 
 source:
-  fn: {{ name }}-v{{ version }}.tar.gz
   url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
-  {{ hash_type }}: {{ hash }}
+  sha256: 62c09f83cbac0904c9aff0a6412f5db2d10e1756fa6c1fc05eeefa15b677fb80
 
 build:
-  skip: True  # [py<36]
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: True  # [py<36]
   entry_points:
     - pre-commit = pre_commit.main:main
     - pre-commit-validate-config = pre_commit.clientlib:validate_config_main
     - pre-commit-validate-manifest = pre_commit.clientlib:validate_manifest_main
 
-requirements:
-  host:
-    - pip
-    - python
+outputs:
+  - name: pre-commit
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
+    requirements:
+      host:
+        - pip
+        - python
+      run:
+        - cfgv >=2.0.0
+        - identify >=1.0.0
+        - importlib_metadata  # [py<38]
+        - importlib_resources  # [py<37]
+        - nodeenv >=0.11.1
+        - python
+        - pyyaml >=5.1
+        - toml
+        - virtualenv >=15.2
+    test:
+      imports:
+        - pre_commit
+        - pre_commit.commands
+        - pre_commit.languages
+      commands:
+        - pre-commit --help
+        - pre-commit-validate-config --help
+        - pre-commit-validate-manifest --help
 
-  run:
-    - cfgv >=2.0.0
-    - identify >=1.0.0
-    - importlib_metadata  # [py<38]
-    - importlib_resources  # [py<37]
-    - nodeenv >=0.11.1
-    - python
-    - pyyaml
-    - toml
-    - virtualenv >=15.2
-
-test:
-  imports:
-    - pre_commit
-    - pre_commit.commands
-    - pre_commit.languages
-  commands:
-    - pre-commit --help
-    - pre-commit-validate-config --help
-    - pre-commit-validate-manifest --help
+  - name: pre_commit
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage('pre-commit', max_pin="x.x.x") }}
+    test:
+      imports:
+        - pre_commit
 
 about:
   home: http://pre-commit.com/


### PR DESCRIPTION
We archived `pre_commit` but some users are still using that name. This will ensure both `-` and `_` variants will be updated.