### PR TITLE
Restrict identify to more recent version

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9d22f9c60b28113b65cc1d96884a609ed98b762222cc8175acb6ffc06221554a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - pre-commit = pre_commit.main:main
@@ -29,7 +29,7 @@ outputs:
         - python >=3.8
       run:
         - cfgv >=2.0.0
-        - identify >=1.0.0
+        - identify >=2.5.20
         - nodeenv >=0.11.1
         - python >=3.8
         - pyyaml >=5.1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

"Official" pre-commit hooks are using featured from newer versions of this library e.g. [pre-commit/mirrors-clang-format](https://github.com/pre-commit/mirrors-clang-format) now uses [textproto](https://github.com/pre-commit/mirrors-clang-format/commit/579d9fe3b1ee34ddd6ebc5def531f2f1acce622e). 

This was added to the identify package ([feedstock](https://github.com/conda-forge/identify-feedstock)) in [v2.5.20](https://github.com/pre-commit/identify/commit/a34721da953e2843144950f4ed47e47a36de8a5a); trying to use this on a pre-commit installed before this was released, fails with:
```
[https://github.com/pre-commit/mirrors-clang-format]
==> File /var/folders/yq/n9kwymws3q317f02dwpl9jrr0000gn/T/tmp1wpaz8q9/.pre-commit-hooks.yaml
==> At Hook(id='clang-format')
==> At key: types_or
==> At index 9
=====> Type tag 'textproto' is not recognized.  Try upgrading identify and pre-commit?
```
Unfortunately, updating pre-commit alone isn't enough to fix - it declares only a dependency to >1.0.0, so you have to know that it's a dependency of the thing you actually asked to install causing the problem. This is easy to miss.

Unfortunately the maintainer seems actively hostile to the suggestion of declaring this dependency: https://github.com/pre-commit/pre-commit/issues/1946 or making it easier for people to understand https://github.com/pre-commit/mirrors-clang-format/issues/24  https://github.com/pre-commit/mirrors-clang-format/issues/24.

This PR moves the conda-forge dependency to a version that will work, which will force dependency updates when pre-commit is itself updated.