### PR TITLE
fix: remove deprecated pre-commit entry points

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,12 +9,10 @@ source:
   sha256: 65d63b57ddec920b09ffdf09536a480d6883eb5069eb295daab6d3fe151e34d3
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - pre-commit = pre_commit.main:main
-    - pre-commit-validate-config = pre_commit.clientlib:validate_config_main
-    - pre-commit-validate-manifest = pre_commit.clientlib:validate_manifest_main
 
 outputs:
   - name: pre-commit


### PR DESCRIPTION
see https://github.com/pre-commit/pre-commit/blob/f56b75dd77a4b6d58cb67a8b5ad626c67837ece6/CHANGELOG.md?plain=1#L169

build: increment build number

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The entry points

- `pre-commit-validate-config`
-  `pre-commit-validate-manifest`

have been removed in version `3.0.0` (https://github.com/pre-commit/pre-commit/blob/f56b75dd77a4b6d58cb67a8b5ad626c67837ece6/CHANGELOG.md?plain=1#L169)

Related pre-commit issue: https://github.com/pre-commit/pre-commit/issues/3002